### PR TITLE
Support for prefix to environment variable names

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -3,18 +3,17 @@
 // license that can be found in the LICENSE file.
 
 // These examples demonstrate more intricate uses of the flag package.
-package flag_test
+package flag
 
 import (
 	"errors"
-	"github.com/namsral/flag"
 	"fmt"
 	"strings"
 	"time"
 )
 
 // Example 1: A single string flag called "species" with default value "gopher".
-var species = flag.String("species", "gopher", "the species we are studying")
+var species = String("species", "gopher", "the species we are studying")
 
 // Example 2: Two flags sharing a variable, so we can have a shorthand.
 // The order of initialization is undefined, so make sure both use the
@@ -26,21 +25,21 @@ func init() {
 		defaultGopher = "pocket"
 		usage         = "the variety of gopher"
 	)
-	flag.StringVar(&gopherType, "gopher_type", defaultGopher, usage)
-	flag.StringVar(&gopherType, "g", defaultGopher, usage+" (shorthand)")
+	StringVar(&gopherType, "gopher_type", defaultGopher, usage)
+	StringVar(&gopherType, "g", defaultGopher, usage+" (shorthand)")
 }
 
 // Example 3: A user-defined flag type, a slice of durations.
 type interval []time.Duration
 
-// String is the method to format the flag's value, part of the flag.Value interface.
+// String is the method to format the flag's value, part of the Value interface.
 // The String method's output will be used in diagnostics.
 func (i *interval) String() string {
 	return fmt.Sprint(*i)
 }
 
-// Set is the method to set the flag value, part of the flag.Value interface.
-// Set's argument is a string to be parsed to set the flag.
+// Set is the method to set the flag value, part of the Value interface.
+// Set's argument is a string to be parsed to set the
 // It's a comma-separated list, so we split it.
 func (i *interval) Set(value string) error {
 	// If we wanted to allow the flag to be set multiple times,
@@ -70,7 +69,7 @@ var intervalFlag interval
 func init() {
 	// Tie the command-line flag to the intervalFlag variable and
 	// set a usage message.
-	flag.Var(&intervalFlag, "deltaT", "comma-separated list of intervals to use between events")
+	Var(&intervalFlag, "deltaT", "comma-separated list of intervals to use between events")
 }
 
 func Example() {

--- a/flag.go
+++ b/flag.go
@@ -73,6 +73,10 @@ import (
 	"time"
 )
 
+// EnvironmentPrefix defines a string that will be implicitely prefixed to a
+// flag name before looking it up in the environment variables.
+var EnvironmentPrefix = ""
+
 // ErrHelp is the error returned if the flag -help is invoked but no such flag is defined.
 var ErrHelp = errors.New("flag: help requested")
 
@@ -269,6 +273,7 @@ type FlagSet struct {
 	parsed        bool
 	actual        map[string]*Flag
 	formal        map[string]*Flag
+	envPrefix     string   // prefix to all env variable names
 	args          []string // arguments after flags
 	exitOnError   bool     // does the program exit if there's an error?
 	errorHandling ErrorHandling
@@ -851,6 +856,9 @@ func (f *FlagSet) ParseEnv(environ []string) error {
 		}
 
 		envKey := strings.ToUpper(flag.Name)
+		if f.envPrefix != "" {
+			envKey = f.envPrefix + "_" + envKey
+		}
 		envKey = strings.Replace(envKey, "-", "_", -1)
 
 		value, isSet := env[envKey]
@@ -1013,10 +1021,20 @@ func NewFlagSet(name string, errorHandling ErrorHandling) *FlagSet {
 	return f
 }
 
-// Init sets the name and error handling property for a flag set.
-// By default, the zero FlagSet uses an empty name and the
+// NewFlagSetWithEnvPrefix returns a new empty flag set with the specified name,
+// environment variable prefix, and error handling property.
+func NewFlagSetWithEnvPrefix(name string, prefix string, errorHandling ErrorHandling) *FlagSet {
+	f := NewFlagSet(name, errorHandling)
+	f.envPrefix = prefix
+	return f
+}
+
+// Init sets the name, environment name prefix, and error handling property
+// for a flag set.
+// By default, the zero FlagSet uses an empty name, EnvironmentPrefix, and the
 // ContinueOnError error handling policy.
 func (f *FlagSet) Init(name string, errorHandling ErrorHandling) {
 	f.name = name
+	f.envPrefix = EnvironmentPrefix
 	f.errorHandling = errorHandling
 }

--- a/flag.go
+++ b/flag.go
@@ -2,63 +2,62 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
-   Package flag implements command-line flag parsing.
+/*Package flag implements command-line flag parsing.
 
-   Usage:
+Usage:
 
-   Define flags using flag.String(), Bool(), Int(), etc.
+Define flags using flag.String(), Bool(), Int(), etc.
 
-   This declares an integer flag, -flagname, stored in the pointer ip, with type *int.
-       import "flag"
-       var ip = flag.Int("flagname", 1234, "help message for flagname")
-   If you like, you can bind the flag to a variable using the Var() functions.
-       var flagvar int
-       func init() {
-           flag.IntVar(&flagvar, "flagname", 1234, "help message for flagname")
-       }
-   Or you can create custom flags that satisfy the Value interface (with
-   pointer receivers) and couple them to flag parsing by
-       flag.Var(&flagVal, "name", "help message for flagname")
-   For such flags, the default value is just the initial value of the variable.
+This declares an integer flag, -flagname, stored in the pointer ip, with type *int.
+    import "flag"
+    var ip = flag.Int("flagname", 1234, "help message for flagname")
+If you like, you can bind the flag to a variable using the Var() functions.
+    var flagvar int
+    func init() {
+        flag.IntVar(&flagvar, "flagname", 1234, "help message for flagname")
+    }
+Or you can create custom flags that satisfy the Value interface (with
+pointer receivers) and couple them to flag parsing by
+    flag.Var(&flagVal, "name", "help message for flagname")
+For such flags, the default value is just the initial value of the variable.
 
-   After all flags are defined, call
-       flag.Parse()
-   to parse the command line into the defined flags.
+After all flags are defined, call
+    flag.Parse()
+to parse the command line into the defined flags.
 
-   Flags may then be used directly. If you're using the flags themselves,
-   they are all pointers; if you bind to variables, they're values.
-       fmt.Println("ip has value ", *ip)
-       fmt.Println("flagvar has value ", flagvar)
+Flags may then be used directly. If you're using the flags themselves,
+they are all pointers; if you bind to variables, they're values.
+    fmt.Println("ip has value ", *ip)
+    fmt.Println("flagvar has value ", flagvar)
 
-   After parsing, the arguments after the flag are available as the
-   slice flag.Args() or individually as flag.Arg(i).
-   The arguments are indexed from 0 through flag.NArg()-1.
+After parsing, the arguments after the flag are available as the
+slice flag.Args() or individually as flag.Arg(i).
+The arguments are indexed from 0 through flag.NArg()-1.
 
-   Command line flag syntax:
-       -flag
-       -flag=x
-       -flag x  // non-boolean flags only
-   One or two minus signs may be used; they are equivalent.
-   The last form is not permitted for boolean flags because the
-   meaning of the command
-       cmd -x *
-   will change if there is a file called 0, false, etc.  You must
-   use the -flag=false form to turn off a boolean flag.
+Command line flag syntax:
+    -flag
+    -flag=x
+    -flag x  // non-boolean flags only
+One or two minus signs may be used; they are equivalent.
+The last form is not permitted for boolean flags because the
+meaning of the command
+    cmd -x *
+will change if there is a file called 0, false, etc.  You must
+use the -flag=false form to turn off a boolean flag.
 
-   Flag parsing stops just before the first non-flag argument
-   ("-" is a non-flag argument) or after the terminator "--".
+Flag parsing stops just before the first non-flag argument
+("-" is a non-flag argument) or after the terminator "--".
 
-   Integer flags accept 1234, 0664, 0x1234 and may be negative.
-   Boolean flags may be 1, 0, t, f, true, false, TRUE, FALSE, True, False.
-   Duration flags accept any input valid for time.ParseDuration.
+Integer flags accept 1234, 0664, 0x1234 and may be negative.
+Boolean flags may be 1, 0, t, f, true, false, TRUE, FALSE, True, False.
+Duration flags accept any input valid for time.ParseDuration.
 
-   The default set of command-line flags is controlled by
-   top-level functions.  The FlagSet type allows one to define
-   independent sets of flags, such as to implement subcommands
-   in a command-line interface. The methods of FlagSet are
-   analogous to the top-level functions for the command-line
-   flag set.
+The default set of command-line flags is controlled by
+top-level functions.  The FlagSet type allows one to define
+independent sets of flags, such as to implement subcommands
+in a command-line interface. The methods of FlagSet are
+analogous to the top-level functions for the command-line
+flag set.
 */
 package flag
 
@@ -720,27 +719,27 @@ func (f *FlagSet) parseOne() (bool, error) {
 	if len(s) == 0 || s[0] != '-' || len(s) == 1 {
 		return false, nil
 	}
-	num_minuses := 1
+	numMinuses := 1
 	if s[1] == '-' {
-		num_minuses++
+		numMinuses++
 		if len(s) == 2 { // "--" terminates the flags
 			f.args = f.args[1:]
 			return false, nil
 		}
 	}
-	name := s[num_minuses:]
+	name := s[numMinuses:]
 	if len(name) == 0 || name[0] == '-' || name[0] == '=' {
 		return false, f.failf("bad flag syntax: %s", s)
 	}
 
 	// it's a flag. does it have an argument?
 	f.args = f.args[1:]
-	has_value := false
+	hasValue := false
 	value := ""
 	for i := 1; i < len(name); i++ { // equals cannot be first
 		if name[i] == '=' {
 			value = name[i+1:]
-			has_value = true
+			hasValue = true
 			name = name[0:i]
 			break
 		}
@@ -755,7 +754,7 @@ func (f *FlagSet) parseOne() (bool, error) {
 		return false, f.failf("flag provided but not defined: -%s", name)
 	}
 	if fv, ok := flag.Value.(boolFlag); ok && fv.IsBoolFlag() { // special case: doesn't need an arg
-		if has_value {
+		if hasValue {
 			if err := fv.Set(value); err != nil {
 				return false, f.failf("invalid boolean value %q for  -%s: %v", value, name, err)
 			}
@@ -764,12 +763,12 @@ func (f *FlagSet) parseOne() (bool, error) {
 		}
 	} else {
 		// It must have a value, which might be the next argument.
-		if !has_value && len(f.args) > 0 {
+		if !hasValue && len(f.args) > 0 {
 			// value is the next arg
-			has_value = true
+			hasValue = true
 			value, f.args = f.args[0], f.args[1:]
 		}
-		if !has_value {
+		if !hasValue {
 			return false, f.failf("flag needs an argument: -%s", name)
 		}
 		if err := flag.Value.Set(value); err != nil {
@@ -812,15 +811,16 @@ func (f *FlagSet) Parse(arguments []string) error {
 	f.ParseEnv(os.Environ())
 
 	// Parse configuration from file
-	config_flag := f.actual["config"]
-	if config_flag != nil {
-		f.ParseFile(config_flag.Value.String())
+	configFlag := f.actual["config"]
+	if configFlag != nil {
+		f.ParseFile(configFlag.Value.String())
 	}
 
 	return nil
 }
 
-// Parse flags from environment variables. Flags already set will be ignored.
+// ParseEnv parses flags from environment variables.
+// Flags already set will be ignored.
 func (f *FlagSet) ParseEnv(environ []string) error {
 
 	m := f.formal
@@ -850,21 +850,21 @@ func (f *FlagSet) ParseEnv(environ []string) error {
 			return f.failf("environment variable provided but not defined: %s", name)
 		}
 
-		env_key := strings.ToUpper(flag.Name)
-		env_key = strings.Replace(env_key, "-", "_", -1)
+		envKey := strings.ToUpper(flag.Name)
+		envKey = strings.Replace(envKey, "-", "_", -1)
 
-		value, is_set := env[env_key]
-		if !is_set {
+		value, isSet := env[envKey]
+		if !isSet {
 			continue
 		}
 
-		has_value := false
+		hasValue := false
 		if len(value) > 0 {
-			has_value = true
+			hasValue = true
 		}
 
 		if fv, ok := flag.Value.(boolFlag); ok && fv.IsBoolFlag() { // special case: doesn't need an arg
-			if has_value {
+			if hasValue {
 				if err := fv.Set(value); err != nil {
 					return f.failf("invalid boolean value %q for environment variable %s: %v", value, name, err)
 				}
@@ -873,7 +873,7 @@ func (f *FlagSet) ParseEnv(environ []string) error {
 				fv.Set("true")
 			}
 		} else {
-			if !has_value {
+			if !hasValue {
 				return f.failf("environment variable needs an value: %s", name)
 			}
 
@@ -892,9 +892,9 @@ func (f *FlagSet) ParseEnv(environ []string) error {
 	return nil
 }
 
-// Parse flags from configuration file. Same format as commandline argumens,
-// newlines and lines beginning with a "#" charater are ignored. Flags already
-// set will be ignored.
+// ParseFile parses flags from the file in path.
+// Same format as commandline argumens, newlines and lines beginning with a
+// "#" charater are ignored. Flags already set will be ignored.
 func (f *FlagSet) ParseFile(path string) error {
 
 	// Extract arguments from file
@@ -920,16 +920,16 @@ func (f *FlagSet) ParseFile(path string) error {
 
 		// Match `key=value` and `key value`
 		var name, value string
-		has_value := false
+		hasValue := false
 		for i, v := range line {
 			if v == '=' || v == ' ' {
-				has_value = true
+				hasValue = true
 				name, value = line[:i], line[i+1:]
 				break
 			}
 		}
 
-		if has_value == false {
+		if hasValue == false {
 			name = line
 		}
 
@@ -949,7 +949,7 @@ func (f *FlagSet) ParseFile(path string) error {
 		}
 
 		if fv, ok := flag.Value.(boolFlag); ok && fv.IsBoolFlag() { // special case: doesn't need an arg
-			if has_value {
+			if hasValue {
 				if err := fv.Set(value); err != nil {
 					return f.failf("invalid boolean value %q for configuration variable %s: %v", value, name, err)
 				}
@@ -958,7 +958,7 @@ func (f *FlagSet) ParseFile(path string) error {
 				fv.Set("true")
 			}
 		} else {
-			if !has_value {
+			if !hasValue {
 				return f.failf("configuration variable needs an argument: %s", name)
 			}
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package flag_test
+package flag
 
 import (
 	"bytes"
 	"fmt"
-	. "github.com/namsral/flag"
 	"os"
 	"sort"
 	"strings"


### PR DESCRIPTION
Added ability to define a prefix to lookup flag names in the environment variables.  Most applications prefix their environment variables with their names because of the global nature of their scope. 

```go

var port int

func Main() {
    flag.Parse() // this would lookup FOO_PORT in the environment variables
}

func init() {
    flag.EnvironmentPrefix = "FOO"
    flag.IntVar(&port, "port", 80, "port number")
}

```

Also, fixed some issues reported by Go Lint and Go Vet