### PR TITLE
if config file is not exist so skip loading arguments from the file

### DIFF
--- a/extras.go
+++ b/extras.go
@@ -106,6 +106,9 @@ func (f *FlagSet) ParseFile(path string) error {
 
 	// Extract arguments from file
 	fp, err := os.Open(path)
+	if os.IsNotExist(err){
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/extras_test.go
+++ b/extras_test.go
@@ -161,8 +161,8 @@ func TestDefaultConfigFlagnameMissingFile(t *testing.T) {
 	if err := os.Unsetenv("STRING"); err != nil {
 		t.Error(err)
 	}
-	if err := f.Parse([]string{}); err == nil {
-		t.Error("expected error of missing config file, got nil")
+	if err := f.Parse([]string{}); err != nil {
+		t.Errorf("expected nil of missing config file, got error: %v",err)
 	}
 }
 


### PR DESCRIPTION
When file is not exist then we can loading arguments from other sources so we don't need exiting from the program. It's not a critical error.