### PR TITLE
Add SetEnvPrefix

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -1005,6 +1005,11 @@ func NewFlagSet(name string, errorHandling ErrorHandling) *FlagSet {
 	return f
 }
 
+// Set the environment prefix for all environment variables.
+func SetEnvPrefix(prefix string) {
+	CommandLine.envPrefix = prefix
+}
+
 // Init sets the name and error handling property for a flag set.
 // By default, the zero FlagSet uses an empty name, EnvironmentPrefix, and the
 // ContinueOnError error handling policy.


### PR DESCRIPTION
This adds the ability to call `flag.SetEnvPrefix("FOO")` such that all environment variables are then parsed as `FOO_`.  It looks like the functionality was always there, just never exposed.