### PR TITLE
Bump to go version 1.14 of flag

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,4 @@
+# Authors
+
+- [Lars Wiegman](https://github.com/namsral)
+- [Justin J. Novack](https://github.com/jnovack)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: update
+
+all: update
+
+update:
+	curl -LO https://raw.githubusercontent.com/golang/go/master/src/flag/example_test.go
+	curl -LO https://raw.githubusercontent.com/golang/go/master/src/flag/example_value_test.go
+	curl -LO https://raw.githubusercontent.com/golang/go/master/src/flag/export_test.go
+	curl -LO https://raw.githubusercontent.com/golang/go/master/src/flag/flag.go
+	curl -LO https://raw.githubusercontent.com/golang/go/master/src/flag/flag_test.go

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-Flag
-===
+# jnovack/flag
 
-Flag is a drop in replacement for Go's flag package with the addition to parse files and environment variables. If you support the [twelve-factor app methodology][], Flag complies with the third factor; "Store config in the environment".
+**jnovack/flag** is a drop in replacement for Go's flag package with the
+addition to parse files and environment variables. If you support the
+[twelve-factor app methodology][], Flag complies with the third factor;
+"Store config in the environment".
 
 [twelve-factor app methodology]: http://12factor.net
 
@@ -13,14 +15,14 @@ $ cat > gopher.go
 
     import (
         "fmt"
-    	"github.com/namsral/flag"
-	)
-    
+        "github.com/jnovack/flag"
+    )
+
     func main() {
-    	var age int
-	flag.IntVar(&age, "age", 0, "age of gopher")
-	flag.Parse()
-	fmt.Print("age:", age)
+        var age int
+    flag.IntVar(&age, "age", 0, "age of gopher")
+    flag.Parse()
+    fmt.Print("age:", age)
     }
 $ go run gopher.go -age 1
 age: 1
@@ -33,7 +35,6 @@ $ export AGE=2
 $ go run gopher.go
 age: 2
 ```
-    
 
 Same code but using a configuration file:
 
@@ -45,7 +46,8 @@ $ go run gopher.go -config gopher.conf
 age: 3
 ```
 
-The following table shows how flags are translated to environment variables and configuration files:
+The following table shows how flags are translated to environment variables
+and configuration files:
 
 | Type   | Flag          | Environment  | File         |
 | ------ | :------------ |:------------ |:------------ |
@@ -54,36 +56,36 @@ The following table shows how flags are translated to environment variables and 
 | float  | -length 175.5 | LENGTH=175.5 | length 175.5 |
 | string | -name Gloria  | NAME=Gloria  | name Gloria  |
 
-This package is a port of Go's [flag][] package from the standard library with the addition of two functions `ParseEnv` and `ParseFile`.
+This package is a port of Go's [flag][] package from the standard library with
+the addition of two functions `ParseEnv` and `ParseFile`.
 
 [flag]: http://golang.org/src/pkg/flag
 
-
-Goals
------
+## Goals
 
 - Compatability with the original `flag` package
 - Support the [twelve-factor app methodology][]
 - Uniform user experience between the three input methods
 
-
-Why?
----
+### Why
 
 Why not use one of the many INI, JSON or YAML parsers?
 
-I find it best practice to have simple configuration options to control the behaviour of an applications when it starts up. Use basic types like ints, floats and strings for configuration options and store more complex data structures in the "datastore" layer.
+I find it best practice to have simple configuration options to control the
+behaviour of an applications when it starts up. Use basic types like ints,
+floats and strings for configuration options and store more complex data
+structures in the "datastore" layer.
 
+## Usage
 
-Usage
----
-
-It's intended for projects which require a simple configuration made available through command-line flags, configuration files and shell environments. It's similar to the original `flag` package.
+It's intended for projects which require a simple configuration made available
+through command-line flags, configuration files and shell environments. It is
+similar to the original `flag` package.
 
 Example:
 
 ```go
-import "github.com/namsral/flag"
+import "github.com/jnovack/flag"
 
 flag.String(flag.DefaultConfigFlagname, "", "path to config file")
 flag.Int("age", 24, "help message for age")
@@ -98,8 +100,7 @@ Order of precedence:
 3. Configuration file
 4. Default values
 
-
-#### Parsing Configuration Files
+### Parsing Configuration Files
 
 Create a configuration file:
 
@@ -127,15 +128,15 @@ Run the command:
 $ go run ./gopher.go -config ./gopher.conf
 ```
 
-The default flag name for the configuration file is "config" and can be changed
-by setting `flag.DefaultConfigFlagname`:
+The default flag name for the configuration file is "config" and can be
+changed by setting `flag.DefaultConfigFlagname`:
 
 ```go
 flag.DefaultConfigFlagname = "conf"
 flag.Parse()
 ```
 
-#### Parsing Environment Variables
+### Parsing Environment Variables
 
 Environment variables are parsed 1-on-1 with defined flags:
 
@@ -145,8 +146,8 @@ $ go run ./gopher.go
 age=44
 ```
 
-
-You can also parse prefixed environment variables by setting a prefix name when creating a new empty flag set:
+You can also parse prefixed environment variables by setting a prefix name
+when creating a new empty flag set:
 
 ```go
 fs := flag.NewFlagSetWithEnvPrefix(os.Args[0], "GO", 0)
@@ -158,42 +159,15 @@ $ go run ./gopher.go
 age=33
 ```
 
-
 For more examples see the [examples][] directory in the project repository.
 
-[examples]: https://github.com/namsral/flag/tree/master/examples
+[examples]: https://github.com/jnovack/flag/tree/master/examples
 
 That's it.
 
+## Credits
 
-License
----
-
-
-Copyright (c) 2012 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**jnovack/flag** would not be possible without
+[@namsral](https://github.com/namsral/flag/) and his work to start this
+project.  To be fair, all I have done is kept this package in step with
+the current released versions of golang.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Flag is a drop in replacement for Go's flag package with the addition to parse f
 
 [twelve-factor app methodology]: http://12factor.net
 
-An example using a gopher:
+An example using a command-line parameter:
 
 ```go
 $ cat > gopher.go

--- a/example_value_test.go
+++ b/example_value_test.go
@@ -1,0 +1,44 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package flag_test
+
+import (
+	"flag"
+	"fmt"
+	"net/url"
+)
+
+type URLValue struct {
+	URL *url.URL
+}
+
+func (v URLValue) String() string {
+	if v.URL != nil {
+		return v.URL.String()
+	}
+	return ""
+}
+
+func (v URLValue) Set(s string) error {
+	if u, err := url.Parse(s); err != nil {
+		return err
+	} else {
+		*v.URL = *u
+	}
+	return nil
+}
+
+var u = &url.URL{}
+
+func ExampleValue() {
+	fs := flag.NewFlagSet("ExampleValue", flag.ExitOnError)
+	fs.Var(&URLValue{u}, "url", "URL to parse")
+
+	fs.Parse([]string{"-url", "https://golang.org/pkg/flag/"})
+	fmt.Printf(`{scheme: %q, host: %q, path: %q}`, u.Scheme, u.Host, u.Path)
+
+	// Output:
+	// {scheme: "https", host: "golang.org", path: "/pkg/flag/"}
+}

--- a/examples/gopher.go
+++ b/examples/gopher.go
@@ -1,29 +1,30 @@
 package main
 
 import (
-    "github.com/namsral/flag"
-    "fmt"
-    )
+	"fmt"
+
+	"github.com/jnovack/flag"
+)
 
 func main() {
-    var (
-        config string
-        length float64
-        age int
-        name string
-        female bool
-    )
+	var (
+		config string
+		length float64
+		age    int
+		name   string
+		female bool
+	)
 
-    flag.StringVar(&config, "config", "", "help message")
-    flag.StringVar(&name, "name", "", "help message")
-    flag.IntVar(&age, "age", 0, "help message")
-    flag.Float64Var(&length, "length", 0, "help message")
-    flag.BoolVar(&female, "female", false, "help message")
-    
-    flag.Parse()
-    
-    fmt.Println("length:", length)
-    fmt.Println("age:", age)
-    fmt.Println("name:", name)
-    fmt.Println("female:", female)
+	flag.StringVar(&config, "config", "", "help message")
+	flag.StringVar(&name, "name", "", "help message")
+	flag.IntVar(&age, "age", 0, "help message")
+	flag.Float64Var(&length, "length", 0, "help message")
+	flag.BoolVar(&female, "female", false, "help message")
+
+	flag.Parse()
+
+	fmt.Println("length:", length)
+	fmt.Println("age:", age)
+	fmt.Println("name:", name)
+	fmt.Println("female:", female)
 }

--- a/export_test.go
+++ b/export_test.go
@@ -8,10 +8,13 @@ import "os"
 
 // Additional routines compiled into the package only during testing.
 
+var DefaultUsage = Usage
+
 // ResetForTesting clears all flag state and sets the usage function as directed.
 // After calling ResetForTesting, parse errors in flag handling will not
 // exit the program.
 func ResetForTesting(usage func()) {
 	CommandLine = NewFlagSet(os.Args[0], ContinueOnError)
+	CommandLine.Usage = commandLineUsage
 	Usage = usage
 }

--- a/extras.go
+++ b/extras.go
@@ -26,7 +26,7 @@ func (f *FlagSet) ParseEnv(environ []string) error {
 		if i < 1 {
 			continue
 		}
-		env[s[0:i]] = s[i+1 : len(s)]
+		env[s[0:i]] = s[i+1:]
 	}
 
 	for _, flag := range m {

--- a/extras.go
+++ b/extras.go
@@ -49,7 +49,10 @@ func (f *FlagSet) ParseEnv(environ []string) error {
 		if f.envPrefix != "" {
 			envKey = f.envPrefix + "_" + envKey
 		}
+		// Replace all dashes (-) with underscores (_)
 		envKey = strings.Replace(envKey, "-", "_", -1)
+		// Replace all periods (.) with underscores (_)
+		envKey = strings.Replace(envKey, ".", "_", -1)
 
 		value, isSet := env[envKey]
 		if !isSet {

--- a/extras_test.go
+++ b/extras_test.go
@@ -171,7 +171,7 @@ func TestFlagSetParseErrors(t *testing.T) {
 	fs.Int("int", 0, "int value")
 
 	args := []string{"-int", "bad"}
-	expected := `invalid value "bad" for flag -int: strconv.ParseInt: parsing "bad": invalid syntax`
+	expected := `invalid value "bad" for flag -int: parse error`
 	if err := fs.Parse(args); err == nil || err.Error() != expected {
 		t.Errorf("expected error %q parsing from args, got: %v", expected, err)
 	}
@@ -179,7 +179,7 @@ func TestFlagSetParseErrors(t *testing.T) {
 	if err := os.Setenv("INT", "bad"); err != nil {
 		t.Fatalf("error setting env: %s", err.Error())
 	}
-	expected = `invalid value "bad" for environment variable int: strconv.ParseInt: parsing "bad": invalid syntax`
+	expected = `invalid value "bad" for environment variable int: parse error`
 	if err := fs.Parse([]string{}); err == nil || err.Error() != expected {
 		t.Errorf("expected error %q parsing from env, got: %v", expected, err)
 	}
@@ -189,7 +189,7 @@ func TestFlagSetParseErrors(t *testing.T) {
 
 	fs.String("config", "", "config filename")
 	args = []string{"-config", "testdata/bad_test.conf"}
-	expected = `invalid value "bad" for configuration variable int: strconv.ParseInt: parsing "bad": invalid syntax`
+	expected = `invalid value "bad" for configuration variable int: parse error`
 	if err := fs.Parse(args); err == nil || err.Error() != expected {
 		t.Errorf("expected error %q parsing from config, got: %v", expected, err)
 	}

--- a/extras_test.go
+++ b/extras_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/namsral/flag"
+	. "github.com/jnovack/flag"
 )
 
 // Test parsing a environment variables

--- a/flag.go
+++ b/flag.go
@@ -5,7 +5,7 @@
 /*
 	Package flag implements command-line flag parsing.
 
-	Usage:
+	Usage
 
 	Define flags using flag.String(), Bool(), Int(), etc.
 
@@ -35,7 +35,10 @@
 	slice flag.Args() or individually as flag.Arg(i).
 	The arguments are indexed from 0 through flag.NArg()-1.
 
-	Command line flag syntax:
+	Command line flag syntax
+
+	The following forms are permitted:
+
 		-flag
 		-flag=x
 		-flag x  // non-boolean flags only
@@ -43,8 +46,9 @@
 	The last form is not permitted for boolean flags because the
 	meaning of the command
 		cmd -x *
-	will change if there is a file called 0, false, etc.  You must
-	use the -flag=false form to turn off a boolean flag.
+	where * is a Unix shell wildcard, will change if there is a file
+	called 0, false, etc. You must use the -flag=false form to turn
+	off a boolean flag.
 
 	Flag parsing stops just before the first non-flag argument
 	("-" is a non-flag argument) or after the terminator "--".
@@ -79,6 +83,28 @@ import (
 // but no such flag is defined.
 var ErrHelp = errors.New("flag: help requested")
 
+// errParse is returned by Set if a flag's value fails to parse, such as with an invalid integer for Int.
+// It then gets wrapped through failf to provide more information.
+var errParse = errors.New("parse error")
+
+// errRange is returned by Set if a flag's value is out of range.
+// It then gets wrapped through failf to provide more information.
+var errRange = errors.New("value out of range")
+
+func numError(err error) error {
+	ne, ok := err.(*strconv.NumError)
+	if !ok {
+		return err
+	}
+	if ne.Err == strconv.ErrSyntax {
+		return errParse
+	}
+	if ne.Err == strconv.ErrRange {
+		return errRange
+	}
+	return err
+}
+
 // -- bool Value
 type boolValue bool
 
@@ -89,13 +115,16 @@ func newBoolValue(val bool, p *bool) *boolValue {
 
 func (b *boolValue) Set(s string) error {
 	v, err := strconv.ParseBool(s)
+	if err != nil {
+		err = errParse
+	}
 	*b = boolValue(v)
 	return err
 }
 
 func (b *boolValue) Get() interface{} { return bool(*b) }
 
-func (b *boolValue) String() string { return fmt.Sprintf("%v", *b) }
+func (b *boolValue) String() string { return strconv.FormatBool(bool(*b)) }
 
 func (b *boolValue) IsBoolFlag() bool { return true }
 
@@ -115,14 +144,17 @@ func newIntValue(val int, p *int) *intValue {
 }
 
 func (i *intValue) Set(s string) error {
-	v, err := strconv.ParseInt(s, 0, 64)
+	v, err := strconv.ParseInt(s, 0, strconv.IntSize)
+	if err != nil {
+		err = numError(err)
+	}
 	*i = intValue(v)
 	return err
 }
 
 func (i *intValue) Get() interface{} { return int(*i) }
 
-func (i *intValue) String() string { return fmt.Sprintf("%v", *i) }
+func (i *intValue) String() string { return strconv.Itoa(int(*i)) }
 
 // -- int64 Value
 type int64Value int64
@@ -134,13 +166,16 @@ func newInt64Value(val int64, p *int64) *int64Value {
 
 func (i *int64Value) Set(s string) error {
 	v, err := strconv.ParseInt(s, 0, 64)
+	if err != nil {
+		err = numError(err)
+	}
 	*i = int64Value(v)
 	return err
 }
 
 func (i *int64Value) Get() interface{} { return int64(*i) }
 
-func (i *int64Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *int64Value) String() string { return strconv.FormatInt(int64(*i), 10) }
 
 // -- uint Value
 type uintValue uint
@@ -151,14 +186,17 @@ func newUintValue(val uint, p *uint) *uintValue {
 }
 
 func (i *uintValue) Set(s string) error {
-	v, err := strconv.ParseUint(s, 0, 64)
+	v, err := strconv.ParseUint(s, 0, strconv.IntSize)
+	if err != nil {
+		err = numError(err)
+	}
 	*i = uintValue(v)
 	return err
 }
 
 func (i *uintValue) Get() interface{} { return uint(*i) }
 
-func (i *uintValue) String() string { return fmt.Sprintf("%v", *i) }
+func (i *uintValue) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 // -- uint64 Value
 type uint64Value uint64
@@ -170,13 +208,16 @@ func newUint64Value(val uint64, p *uint64) *uint64Value {
 
 func (i *uint64Value) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 64)
+	if err != nil {
+		err = numError(err)
+	}
 	*i = uint64Value(v)
 	return err
 }
 
 func (i *uint64Value) Get() interface{} { return uint64(*i) }
 
-func (i *uint64Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *uint64Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 // -- string Value
 type stringValue string
@@ -193,7 +234,7 @@ func (s *stringValue) Set(val string) error {
 
 func (s *stringValue) Get() interface{} { return string(*s) }
 
-func (s *stringValue) String() string { return fmt.Sprintf("%s", *s) }
+func (s *stringValue) String() string { return string(*s) }
 
 // -- float64 Value
 type float64Value float64
@@ -205,13 +246,16 @@ func newFloat64Value(val float64, p *float64) *float64Value {
 
 func (f *float64Value) Set(s string) error {
 	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		err = numError(err)
+	}
 	*f = float64Value(v)
 	return err
 }
 
 func (f *float64Value) Get() interface{} { return float64(*f) }
 
-func (f *float64Value) String() string { return fmt.Sprintf("%v", *f) }
+func (f *float64Value) String() string { return strconv.FormatFloat(float64(*f), 'g', -1, 64) }
 
 // -- time.Duration Value
 type durationValue time.Duration
@@ -223,6 +267,9 @@ func newDurationValue(val time.Duration, p *time.Duration) *durationValue {
 
 func (d *durationValue) Set(s string) error {
 	v, err := time.ParseDuration(s)
+	if err != nil {
+		err = errParse
+	}
 	*d = durationValue(v)
 	return err
 }
@@ -239,6 +286,8 @@ func (d *durationValue) String() string { return (*time.Duration)(d).String() }
 // rather than using the next command-line argument.
 //
 // Set is called once, in command line order, for each flag present.
+// The flag package may call the String method with a zero-valued receiver,
+// such as a nil pointer.
 type Value interface {
 	String() string
 	Set(string) error
@@ -265,10 +314,15 @@ const (
 
 // A FlagSet represents a set of defined flags. The zero value of a FlagSet
 // has no name and has ContinueOnError error handling.
+//
+// Flag names must be unique within a FlagSet. An attempt to define a flag whose
+// name is already in use will cause a panic.
 type FlagSet struct {
 	// Usage is the function called when an error occurs while parsing flags.
 	// The field is a function (not a method) that may be changed to point to
-	// a custom error handler.
+	// a custom error handler. What happens after Usage is called depends
+	// on the ErrorHandling setting; for the command line, this defaults
+	// to ExitOnError, which exits the program after calling Usage.
 	Usage func()
 
 	name          string
@@ -291,25 +345,35 @@ type Flag struct {
 
 // sortFlags returns the flags as a slice in lexicographical sorted order.
 func sortFlags(flags map[string]*Flag) []*Flag {
-	list := make(sort.StringSlice, len(flags))
+	result := make([]*Flag, len(flags))
 	i := 0
 	for _, f := range flags {
-		list[i] = f.Name
+		result[i] = f
 		i++
 	}
-	list.Sort()
-	result := make([]*Flag, len(list))
-	for i, name := range list {
-		result[i] = flags[name]
-	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
 	return result
 }
 
-func (f *FlagSet) out() io.Writer {
+// Output returns the destination for usage and error messages. os.Stderr is returned if
+// output was not set or was set to nil.
+func (f *FlagSet) Output() io.Writer {
 	if f.output == nil {
 		return os.Stderr
 	}
 	return f.output
+}
+
+// Name returns the name of the flag set.
+func (f *FlagSet) Name() string {
+	return f.name
+}
+
+// ErrorHandling returns the error handling behavior of the flag set.
+func (f *FlagSet) ErrorHandling() ErrorHandling {
+	return f.errorHandling
 }
 
 // SetOutput sets the destination for usage and error messages.
@@ -379,8 +443,8 @@ func Set(name, value string) error {
 	return CommandLine.Set(name, value)
 }
 
-// isZeroValue guesses whether the string represents the zero
-// value for a flag. It is not accurate but in practice works OK.
+// isZeroValue determines whether the string represents the zero
+// value for a flag.
 func isZeroValue(flag *Flag, value string) bool {
 	// Build a zero value of the flag's Value type, and see if the
 	// result of calling its String method equals the value passed in.
@@ -392,19 +456,7 @@ func isZeroValue(flag *Flag, value string) bool {
 	} else {
 		z = reflect.Zero(typ)
 	}
-	if value == z.Interface().(Value).String() {
-		return true
-	}
-
-	switch value {
-	case "false":
-		return true
-	case "":
-		return true
-	case "0":
-		return true
-	}
-	return false
+	return value == z.Interface().(Value).String()
 }
 
 // UnquoteUsage extracts a back-quoted name from the usage
@@ -446,9 +498,9 @@ func UnquoteUsage(flag *Flag) (name string, usage string) {
 	return
 }
 
-// PrintDefaults prints to standard error the default values of all
-// defined command-line flags in the set. See the documentation for
-// the global function PrintDefaults for more information.
+// PrintDefaults prints, to standard error unless configured otherwise, the
+// default values of all defined command-line flags in the set. See the
+// documentation for the global function PrintDefaults for more information.
 func (f *FlagSet) PrintDefaults() {
 	f.VisitAll(func(flag *Flag) {
 		s := fmt.Sprintf("  -%s", flag.Name) // Two spaces before -; see next two comments.
@@ -465,7 +517,8 @@ func (f *FlagSet) PrintDefaults() {
 			// for both 4- and 8-space tab stops.
 			s += "\n    \t"
 		}
-		s += usage
+		s += strings.ReplaceAll(usage, "\n", "\n    \t")
+
 		if !isZeroValue(flag, flag.DefValue) {
 			if _, ok := flag.Value.(*stringValue); ok {
 				// put quotes on the value
@@ -474,7 +527,7 @@ func (f *FlagSet) PrintDefaults() {
 				s += fmt.Sprintf(" (default %v)", flag.DefValue)
 			}
 		}
-		fmt.Fprint(f.out(), s, "\n")
+		fmt.Fprint(f.Output(), s, "\n")
 	})
 }
 
@@ -497,16 +550,18 @@ func (f *FlagSet) PrintDefaults() {
 // the output will be
 //	-I directory
 //		search directory for include files.
+//
+// To change the destination for flag messages, call CommandLine.SetOutput.
 func PrintDefaults() {
 	CommandLine.PrintDefaults()
 }
 
 // defaultUsage is the default function to print a usage message.
-func defaultUsage(f *FlagSet) {
+func (f *FlagSet) defaultUsage() {
 	if f.name == "" {
-		fmt.Fprintf(f.out(), "Usage:\n")
+		fmt.Fprintf(f.Output(), "Usage:\n")
 	} else {
-		fmt.Fprintf(f.out(), "Usage of %s:\n", f.name)
+		fmt.Fprintf(f.Output(), "Usage of %s:\n", f.name)
 	}
 	f.PrintDefaults()
 }
@@ -515,13 +570,17 @@ func defaultUsage(f *FlagSet) {
 // because it serves (via godoc flag Usage) as the example
 // for how to write your own usage function.
 
-// Usage prints to standard error a usage message documenting all defined command-line flags.
+// Usage prints a usage message documenting all defined command-line flags
+// to CommandLine's output, which by default is os.Stderr.
 // It is called when an error occurs while parsing flags.
 // The function is a variable that may be changed to point to a custom function.
 // By default it prints a simple header and calls PrintDefaults; for details about the
 // format of the output and how to control it, see the documentation for PrintDefaults.
+// Custom usage functions may choose to exit the program; by default exiting
+// happens anyway as the command line's error handling strategy is set to
+// ExitOnError.
 var Usage = func() {
-	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+	fmt.Fprintf(CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 	PrintDefaults()
 }
 
@@ -645,13 +704,13 @@ func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string) {
 }
 
 // UintVar defines a uint flag with specified name, default value, and usage string.
-// The argument p points to a uint  variable in which to store the value of the flag.
+// The argument p points to a uint variable in which to store the value of the flag.
 func UintVar(p *uint, name string, value uint, usage string) {
 	CommandLine.Var(newUintValue(value, p), name, usage)
 }
 
 // Uint defines a uint flag with specified name, default value, and usage string.
-// The return value is the address of a uint  variable that stores the value of the flag.
+// The return value is the address of a uint variable that stores the value of the flag.
 func (f *FlagSet) Uint(name string, value uint, usage string) *uint {
 	p := new(uint)
 	f.UintVar(p, name, value, usage)
@@ -659,7 +718,7 @@ func (f *FlagSet) Uint(name string, value uint, usage string) *uint {
 }
 
 // Uint defines a uint flag with specified name, default value, and usage string.
-// The return value is the address of a uint  variable that stores the value of the flag.
+// The return value is the address of a uint variable that stores the value of the flag.
 func Uint(name string, value uint, usage string) *uint {
 	return CommandLine.Uint(name, value, usage)
 }
@@ -789,7 +848,7 @@ func (f *FlagSet) Var(value Value, name string, usage string) {
 		} else {
 			msg = fmt.Sprintf("%s flag redefined: %s", f.name, name)
 		}
-		fmt.Fprintln(f.out(), msg)
+		fmt.Fprintln(f.Output(), msg)
 		panic(msg) // Happens only if flags are declared with identical names
 	}
 	if f.formal == nil {
@@ -812,7 +871,7 @@ func Var(value Value, name string, usage string) {
 // returns the error.
 func (f *FlagSet) failf(format string, a ...interface{}) error {
 	err := fmt.Errorf(format, a...)
-	fmt.Fprintln(f.out(), err)
+	fmt.Fprintln(f.Output(), err)
 	f.usage()
 	return err
 }
@@ -824,7 +883,7 @@ func (f *FlagSet) usage() {
 		if f == CommandLine {
 			Usage()
 		} else {
-			defaultUsage(f)
+			f.defaultUsage()
 		}
 	} else {
 		f.Usage()
@@ -837,7 +896,7 @@ func (f *FlagSet) parseOne() (bool, error) {
 		return false, nil
 	}
 	s := f.args[0]
-	if len(s) == 0 || s[0] != '-' || len(s) == 1 {
+	if len(s) < 2 || s[0] != '-' {
 		return false, nil
 	}
 	numMinuses := 1
@@ -879,6 +938,7 @@ func (f *FlagSet) parseOne() (bool, error) {
 		}
 		return false, f.failf("flag provided but not defined: -%s", name)
 	}
+
 	if fv, ok := flag.Value.(boolFlag); ok && fv.IsBoolFlag() { // special case: doesn't need an arg
 		if hasValue {
 			if err := fv.Set(value); err != nil {
@@ -978,7 +1038,7 @@ func (f *FlagSet) Parsed() bool {
 	return f.parsed
 }
 
-// Parse parses the command-line flags from os.Args[1:].  Must be called
+// Parse parses the command-line flags from os.Args[1:]. Must be called
 // after all flags are defined and before flags are accessed by the program.
 func Parse() {
 	// Ignore errors; CommandLine is set for ExitOnError.
@@ -995,13 +1055,27 @@ func Parsed() bool {
 // methods of CommandLine.
 var CommandLine = NewFlagSet(os.Args[0], ExitOnError)
 
+func init() {
+	// Override generic FlagSet default Usage with call to global Usage.
+	// Note: This is not CommandLine.Usage = Usage,
+	// because we want any eventual call to use any updated value of Usage,
+	// not the value it has when this line is run.
+	CommandLine.Usage = commandLineUsage
+}
+
+func commandLineUsage() {
+	Usage()
+}
+
 // NewFlagSet returns a new, empty flag set with the specified name and
-// error handling property.
+// error handling property. If the name is not empty, it will be printed
+// in the default usage message and in error messages.
 func NewFlagSet(name string, errorHandling ErrorHandling) *FlagSet {
 	f := &FlagSet{
 		name:          name,
 		errorHandling: errorHandling,
 	}
+	f.Usage = f.defaultUsage
 	return f
 }
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -7,9 +7,12 @@ package flag_test
 import (
 	"bytes"
 	"fmt"
+	"internal/testenv"
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -542,6 +545,69 @@ func TestRangeError(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "invalid") || !strings.Contains(err.Error(), "value out of range") {
 			t.Errorf("Parse(%q)=%v; expected range error", arg, err)
+		}
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	testenv.MustHaveExec(t)
+
+	magic := 123
+	if os.Getenv("GO_CHILD_FLAG") != "" {
+		fs := NewFlagSet("test", ExitOnError)
+		if os.Getenv("GO_CHILD_FLAG_HANDLE") != "" {
+			var b bool
+			fs.BoolVar(&b, os.Getenv("GO_CHILD_FLAG_HANDLE"), false, "")
+		}
+		fs.Parse([]string{os.Getenv("GO_CHILD_FLAG")})
+		os.Exit(magic)
+	}
+
+	tests := []struct {
+		flag       string
+		flagHandle string
+		expectExit int
+	}{
+		{
+			flag:       "-h",
+			expectExit: 0,
+		},
+		{
+			flag:       "-help",
+			expectExit: 0,
+		},
+		{
+			flag:       "-undefined",
+			expectExit: 2,
+		},
+		{
+			flag:       "-h",
+			flagHandle: "h",
+			expectExit: magic,
+		},
+		{
+			flag:       "-help",
+			flagHandle: "help",
+			expectExit: magic,
+		},
+	}
+
+	for _, test := range tests {
+		cmd := exec.Command(os.Args[0], "-test.run=TestExitCode")
+		cmd.Env = append(
+			os.Environ(),
+			"GO_CHILD_FLAG="+test.flag,
+			"GO_CHILD_FLAG_HANDLE="+test.flagHandle,
+		)
+		cmd.Run()
+		got := cmd.ProcessState.ExitCode()
+		// ExitCode is either 0 or 1 on Plan 9.
+		if runtime.GOOS == "plan9" && test.expectExit != 0 {
+			test.expectExit = 1
+		}
+		if got != test.expectExit {
+			t.Errorf("unexpected exit code for test case %+v \n: got %d, expect %d",
+				test, got, test.expectExit)
 		}
 	}
 }

--- a/flag_test.go
+++ b/flag_test.go
@@ -7,19 +7,16 @@ package flag_test
 import (
 	"bytes"
 	"fmt"
-	"internal/testenv"
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	. "github.com/namsral/flag"
+	. "github.com/jnovack/flag"
 )
 
 func boolString(s string) string {
@@ -549,65 +546,4 @@ func TestRangeError(t *testing.T) {
 	}
 }
 
-func TestExitCode(t *testing.T) {
-	testenv.MustHaveExec(t)
-
-	magic := 123
-	if os.Getenv("GO_CHILD_FLAG") != "" {
-		fs := NewFlagSet("test", ExitOnError)
-		if os.Getenv("GO_CHILD_FLAG_HANDLE") != "" {
-			var b bool
-			fs.BoolVar(&b, os.Getenv("GO_CHILD_FLAG_HANDLE"), false, "")
-		}
-		fs.Parse([]string{os.Getenv("GO_CHILD_FLAG")})
-		os.Exit(magic)
-	}
-
-	tests := []struct {
-		flag       string
-		flagHandle string
-		expectExit int
-	}{
-		{
-			flag:       "-h",
-			expectExit: 0,
-		},
-		{
-			flag:       "-help",
-			expectExit: 0,
-		},
-		{
-			flag:       "-undefined",
-			expectExit: 2,
-		},
-		{
-			flag:       "-h",
-			flagHandle: "h",
-			expectExit: magic,
-		},
-		{
-			flag:       "-help",
-			flagHandle: "help",
-			expectExit: magic,
-		},
-	}
-
-	for _, test := range tests {
-		cmd := exec.Command(os.Args[0], "-test.run=TestExitCode")
-		cmd.Env = append(
-			os.Environ(),
-			"GO_CHILD_FLAG="+test.flag,
-			"GO_CHILD_FLAG_HANDLE="+test.flagHandle,
-		)
-		cmd.Run()
-		got := cmd.ProcessState.ExitCode()
-		// ExitCode is either 0 or 1 on Plan 9.
-		if runtime.GOOS == "plan9" && test.expectExit != 0 {
-			test.expectExit = 1
-		}
-		if got != test.expectExit {
-			t.Errorf("unexpected exit code for test case %+v \n: got %d, expect %d",
-				test, got, test.expectExit)
-		}
-	}
-}
+// /* jnovack/flag cannot import TextExitCode because it relies on internal/testenv */

--- a/flag_test.go
+++ b/flag_test.go
@@ -7,8 +7,11 @@ package flag_test
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -385,12 +388,20 @@ const defaultOutput = `  -A	for bootstrapping, allow 'any' type
   -C	a boolean defaulting to true (default true)
   -D path
     	set relative path for local imports
+  -E string
+    	issue 23543 (default "0")
   -F number
     	a non-zero number (default 2.7)
   -G float
     	a float that defaults to zero
+  -M string
+    	a multiline
+    	help
+    	string
   -N int
     	a non-zero int (default 27)
+  -O	a flag
+    	multiline help string (default true)
   -Z int
     	an int that defaults to zero
   -maxT timeout
@@ -405,14 +416,132 @@ func TestPrintDefaults(t *testing.T) {
 	fs.Bool("Alongflagname", false, "disable bounds checking")
 	fs.Bool("C", true, "a boolean defaulting to true")
 	fs.String("D", "", "set relative `path` for local imports")
+	fs.String("E", "0", "issue 23543")
 	fs.Float64("F", 2.7, "a non-zero `number`")
 	fs.Float64("G", 0, "a float that defaults to zero")
+	fs.String("M", "", "a multiline\nhelp\nstring")
 	fs.Int("N", 27, "a non-zero int")
+	fs.Bool("O", true, "a flag\nmultiline help string")
 	fs.Int("Z", 0, "an int that defaults to zero")
 	fs.Duration("maxT", 0, "set `timeout` for dial")
 	fs.PrintDefaults()
 	got := buf.String()
 	if got != defaultOutput {
 		t.Errorf("got %q want %q\n", got, defaultOutput)
+	}
+}
+
+// Issue 19230: validate range of Int and Uint flag values.
+func TestIntFlagOverflow(t *testing.T) {
+	if strconv.IntSize != 32 {
+		return
+	}
+	ResetForTesting(nil)
+	Int("i", 0, "")
+	Uint("u", 0, "")
+	if err := Set("i", "2147483648"); err == nil {
+		t.Error("unexpected success setting Int")
+	}
+	if err := Set("u", "4294967296"); err == nil {
+		t.Error("unexpected success setting Uint")
+	}
+}
+
+// Issue 20998: Usage should respect CommandLine.output.
+func TestUsageOutput(t *testing.T) {
+	ResetForTesting(DefaultUsage)
+	var buf bytes.Buffer
+	CommandLine.SetOutput(&buf)
+	defer func(old []string) { os.Args = old }(os.Args)
+	os.Args = []string{"app", "-i=1", "-unknown"}
+	Parse()
+	const want = "flag provided but not defined: -i\nUsage of app:\n"
+	if got := buf.String(); got != want {
+		t.Errorf("output = %q; want %q", got, want)
+	}
+}
+
+func TestGetters(t *testing.T) {
+	expectedName := "flag set"
+	expectedErrorHandling := ContinueOnError
+	expectedOutput := io.Writer(os.Stderr)
+	fs := NewFlagSet(expectedName, expectedErrorHandling)
+
+	if fs.Name() != expectedName {
+		t.Errorf("unexpected name: got %s, expected %s", fs.Name(), expectedName)
+	}
+	if fs.ErrorHandling() != expectedErrorHandling {
+		t.Errorf("unexpected ErrorHandling: got %d, expected %d", fs.ErrorHandling(), expectedErrorHandling)
+	}
+	if fs.Output() != expectedOutput {
+		t.Errorf("unexpected output: got %#v, expected %#v", fs.Output(), expectedOutput)
+	}
+
+	expectedName = "gopher"
+	expectedErrorHandling = ExitOnError
+	expectedOutput = os.Stdout
+	fs.Init(expectedName, expectedErrorHandling)
+	fs.SetOutput(expectedOutput)
+
+	if fs.Name() != expectedName {
+		t.Errorf("unexpected name: got %s, expected %s", fs.Name(), expectedName)
+	}
+	if fs.ErrorHandling() != expectedErrorHandling {
+		t.Errorf("unexpected ErrorHandling: got %d, expected %d", fs.ErrorHandling(), expectedErrorHandling)
+	}
+	if fs.Output() != expectedOutput {
+		t.Errorf("unexpected output: got %v, expected %v", fs.Output(), expectedOutput)
+	}
+}
+
+func TestParseError(t *testing.T) {
+	for _, typ := range []string{"bool", "int", "int64", "uint", "uint64", "float64", "duration"} {
+		fs := NewFlagSet("parse error test", ContinueOnError)
+		fs.SetOutput(ioutil.Discard)
+		_ = fs.Bool("bool", false, "")
+		_ = fs.Int("int", 0, "")
+		_ = fs.Int64("int64", 0, "")
+		_ = fs.Uint("uint", 0, "")
+		_ = fs.Uint64("uint64", 0, "")
+		_ = fs.Float64("float64", 0, "")
+		_ = fs.Duration("duration", 0, "")
+		// Strings cannot give errors.
+		args := []string{"-" + typ + "=x"}
+		err := fs.Parse(args) // x is not a valid setting for any flag.
+		if err == nil {
+			t.Errorf("Parse(%q)=%v; expected parse error", args, err)
+			continue
+		}
+		if !strings.Contains(err.Error(), "invalid") || !strings.Contains(err.Error(), "parse error") {
+			t.Errorf("Parse(%q)=%v; expected parse error", args, err)
+		}
+	}
+}
+
+func TestRangeError(t *testing.T) {
+	bad := []string{
+		"-int=123456789012345678901",
+		"-int64=123456789012345678901",
+		"-uint=123456789012345678901",
+		"-uint64=123456789012345678901",
+		"-float64=1e1000",
+	}
+	for _, arg := range bad {
+		fs := NewFlagSet("parse error test", ContinueOnError)
+		fs.SetOutput(ioutil.Discard)
+		_ = fs.Int("int", 0, "")
+		_ = fs.Int64("int64", 0, "")
+		_ = fs.Uint("uint", 0, "")
+		_ = fs.Uint64("uint64", 0, "")
+		_ = fs.Float64("float64", 0, "")
+		// Strings cannot give errors, and bools and durations do not return strconv.NumError.
+		err := fs.Parse([]string{arg})
+		if err == nil {
+			t.Errorf("Parse(%q)=%v; expected range error", arg, err)
+			continue
+		}
+		if !strings.Contains(err.Error(), "invalid") || !strings.Contains(err.Error(), "value out of range") {
+			t.Errorf("Parse(%q)=%v; expected range error", arg, err)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/namsral/flag
+module github.com/jnovack/flag
 
-go 1.14
+go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/namsral/flag
+
+go 1.14


### PR DESCRIPTION
This ports the changes in `golang/pkg/flag` v1.14 to this package.

Seeing as this it the v1.14 version of the golang package, I HEAVILY RECOMMEND bumping this repository to `v1.14.0` to maintain feature parity with golang versions. 